### PR TITLE
Fixed | CSS for images and safari

### DIFF
--- a/public/styles/base.css
+++ b/public/styles/base.css
@@ -12,9 +12,9 @@ body {
 }
 
 img {
-  max-width: 500px;
+  max-width: 100%;
 }
 
 main {
-  width: 507px;
+  width: 100%;
 }

--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -28,7 +28,7 @@ main {
 }
 
 .quote-card {
-  margin-top: 200px;
+  margin-top: 140px;
   margin-left: 30px;
   margin-right: 30px;
 }

--- a/public/styles/modules/modules.css
+++ b/public/styles/modules/modules.css
@@ -97,18 +97,18 @@
 
 .stuff {
   display: flex;
-  margin: 20px;
+  align-items: center;
+  margin-top: 20px;
 }
 
 .bio-card {
   width: 85%;
   height: fit-content;
   text-align: center;
+  padding: 20px;
+  box-sizing: border-box;
 }
 
-.bio-card > img {
-  margin-top: 20px;
-}
 
 .stuff h2 {
   font-size: 1.2rem;
@@ -124,7 +124,7 @@
 }
 
 .about-links img {
-  width: 45px;
+  min-width: 45px;
 }
 
 .about-links img:first-child {

--- a/views/pages/about.ejs
+++ b/views/pages/about.ejs
@@ -8,7 +8,7 @@
   
   <section class="bio-card">
 
-    <img src="/img/tif.jpg" alt="tif" style="height: 350px">
+    <img src="/img/tif.jpg" alt="tif">
 
     <div class="stuff">
       <div class="about-text">
@@ -29,7 +29,7 @@
 
   <section class="bio-card">
 
-    <img src="/img/chandler.jpg" alt="chandler" style="height: 350px">
+    <img src="/img/chandler.jpg" alt="chandler">
 
     <div class="stuff">
       <div class="about-text">
@@ -50,7 +50,7 @@
 
   <section class="bio-card">
 
-    <img src="/img/jack.jpg" alt="jack" style="height: 300px">
+    <img src="/img/jack.jpg" alt="jack">
 
     <div class="stuff">
       <div class="about-text">


### PR DESCRIPTION
- I updated the lines necessary for better safari mobile browser use
- I fixed the new square images that were breaking out of section and added code to ensure the new square images would stay inside the section card (tif and chandlers) 
- made sure aspect ratio stayed for about images (since it wasn't sticking on response)
- Updated quote margin top for potential presentation in mobile view using the Pixel 2 XL (it looked the prettiest) :) 