### PR TITLE
Fixes | quote catch, img paths

### DIFF
--- a/server.js
+++ b/server.js
@@ -39,27 +39,17 @@ function homePage (req, res) {
 
   const apiQuery = `http://api.forismatic.com/api/1.0/?method=getQuote&format=json&lang=en`;
 
-  
-
   superagent.get(apiQuery)
     .then(result => {
       const quote = new Quotes(result);
       res.render('pages/index', {data: quote});
     })
+    // a manual quote will populate if the API gives error
     .catch(()=> {
-      superagent.get(apiQuery)
-        .then(result => {
-          const quote = new Quotes(result);
+          const quote = {text:'Catching errors like a fisherman catches fish.', author: 'Tif Taylor'};
           res.render('pages/index', {data: quote});
         })
-        .catch(()=>{
-          superagent.get(apiQuery)
-            .then(result => {
-              const quote = new Quotes(result);
-              res.render('pages/index', {data: quote});
-            });
-        });
-    });
+        .catch(error => errorHandler(error, res));
 }
 
 

--- a/views/layout/top.ejs
+++ b/views/layout/top.ejs
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="/styles/modules/footer.css">
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display&display=swap" rel="stylesheet">
 
-  <link rel="icon" href="../../images/Respite-favicon-WHITE.jpg" type="image/x-icon">
+  <link rel="icon" href="/img/Respite-favicon-WHITE.jpg" type="image/x-icon">
 
 </head>
 

--- a/views/pages/error.ejs
+++ b/views/pages/error.ejs
@@ -7,7 +7,7 @@
 
   <section>
     
-    <img src="/public/img/error.png" alt="error">
+    <img src="/img/error.png" alt="error">
 
   </section>
 


### PR DESCRIPTION
- Added a manual quote in the first catch of the homePage callback to avoid breaking
- Added usual error page catch as the final catch if manual quote doesn't load in homePage callback
- Fixed file paths to images in top.ejs and error.ejs fixed